### PR TITLE
Add data products page, shorten title

### DIFF
--- a/docs/products/lsdb.rst
+++ b/docs/products/lsdb.rst
@@ -10,4 +10,4 @@ Built on top of `Dask <https://docs.dask.org/en/stable/>`_,
 LSDB uses the `HATS <https://hats.readthedocs.io/en/stable/>`_ (Hierarchical Adaptive Tiling Scheme) data format to efficiently perform spatial operations.
 
 Find LSDB tutorials for accessing Rubin data at `lsdb.io/dp1 <https://docs.lsdb.io/en/latest/tutorials/pre_executed/rubin_dp1.html>`_.
-Additional information and explanations of different DP1 LSDB data products are available at `data.lsdb.io/#Rubin_DP1 <https://data.lsdb.io/#Rubin_DP1>`_.
+Additional information and explanations of different DP1 LSDB data products are available at `data.lsdb.io <https://data.lsdb.io/>`_.


### PR DESCRIPTION
This pull:

1. Only leaves lsdb as the name of the page. We have decided to not use any long form name anymore. 
2. Adds link to the webpage where data products can be found